### PR TITLE
Remove final for private method

### DIFF
--- a/src/IconSet.php
+++ b/src/IconSet.php
@@ -78,7 +78,7 @@ abstract class IconSet implements Plugin
     | Helpers
     |--------------------------------------------------------------------------
     */
-    final private function setOverriddenStyle(array|string $items, string $style, string $type = 'aliases'): void
+    private function setOverriddenStyle(array|string $items, string $style, string $type = 'aliases'): void
     {
         $items = is_array($items) ? $items : [$items];
         $overrideType = $type === 'aliases' ? 'overriddenAliases' : 'overriddenIcons';


### PR DESCRIPTION
Private methods cannot be final as they are never overridden by other classes.

This gives a warning as per: https://php.watch/versions/8.0/final-private-function