### PR TITLE
refactor: Remove final from register method

### DIFF
--- a/src/IconSet.php
+++ b/src/IconSet.php
@@ -123,7 +123,7 @@ abstract class IconSet implements Plugin
         return app(static::class);
     }
 
-    final public function register(Panel $panel): void
+    public function register(Panel $panel): void
     {
         //
     }


### PR DESCRIPTION
This PR removes the final modifier from the `register` method in the `IconSet` class.
Enables users to extend and override the method in their own implementations, providing flexibility for customization and project-specific behavior.

This adjustment does not affect existing behavior but opens the door for more extensible use cases.